### PR TITLE
DRAFT: macos: Make relative move without querying the current location first

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@
 ## Added
 - Linux: Support X11 without `xdotools`. Use the experimental feature `x11rb` to test it
 - Linux: Partial support for Wayland was added. Use the experimental feature `wayland` to test it. Only the virtual_keyboard and input_method protocol can be used. This is not going to work on GNOME, but should work for example with phosh
+
 ## Fixed
 - macOS: Add info how much a mouse was moved relative to the last position
 - macOS: A mouse drag with the right key is now possible too
+- macOS: Remove sleep from `enter_key` function and set the proper modifier flags
 
 # 0.1.3
 


### PR DESCRIPTION
This PR is just so that the actions are ran to try to build it