### PR TITLE
CI: Checkout the correct commit and allow manually running the workflow

### DIFF
--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   additional_tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}  # Only run if the integration tests succeeded
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}  # Only run if the build succeeded
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +60,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # If manually triggered, use the current commit (GITHUB_SHA), otherwise use the head_sha from the Build workflow
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/install_deps
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   integration:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}  # Only run if the build succeeded
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}  # Only run if the build succeeded
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +58,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # If manually triggered, use the current commit (GITHUB_SHA), otherwise use the head_sha from the Build workflow
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/install_deps
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}  # Only run if the build succeeded
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}  # Only run if the build succeeded
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +60,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # If manually triggered, use the current commit (GITHUB_SHA), otherwise use the head_sha from the Build workflow
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/install_deps
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
When the workflows were separated, the workflows that were started from other workflows all checked out the code of the main branch. The behavior was changed so that they checkout the same commit